### PR TITLE
feat: supports forced HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ async def main():
     client.on_message(on_message_handler)
 
     # 连接到服务器（必须指定endpoint）
+    # 兼容 "IP:PORT", "ws://IP:PORT", "wss://IP:PORT" 格式
+    # 对于 IP:PORT，会自动探测是否强制 HTTPS/WSS 并跟随端口
+    # 如果是自签证书，需传入 ssl_verify=False
     await client.connect(args.endpoint)
 
     # 登录
@@ -152,3 +155,4 @@ uv run examples/user.py --user myuser --password mypassword -e my-server.com:566
 | `user.py` | 演示User模块的各种功能（获取用户信息、用户组等） |
 | `network.py` | 演示如何获取网络信息（支持type参数，可选值为0和1）和检测网络接口（支持ifName参数） |
 | `file.py` | 演示File模块的各种功能（列出文件、创建文件夹、删除文件/文件夹） |
+| `endpoint_detection.py` | 演示端点自动探测功能及 SSL 验证设置 |

--- a/examples/endpoint_detection.py
+++ b/examples/endpoint_detection.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+FnosClient 端点自动识别与 SSL 配置示例
+演示如何使用 _detect_endpoint() 自动探测服务器地址，以及如何处理 SSL 验证
+"""
+
+import asyncio
+import argparse
+import sys
+import os
+
+# 添加项目根目录到Python路径
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from fnos.client import FnosClient
+
+
+async def main():
+    """主函数"""
+    parser = argparse.ArgumentParser(description="FnosClient 端点探测示例")
+    parser.add_argument("--user", type=str, required=True, help="用户名")
+    parser.add_argument("--password", type=str, required=True, help="密码")
+
+    # 示例 1: 原始 IP:PORT 写法，将自动探测是否需要 HTTPS/WSS
+    parser.add_argument(
+        "-e",
+        "--endpoint",
+        type=str,
+        default="192.168.1.100:5666",
+        help="服务器地址，支持 IP:PORT, ws://IP:PORT 或 wss://IP:PORT",
+    )
+
+    # 是否跳过 SSL 验证 (如果是自签证书)
+    parser.add_argument(
+        "--no-verify", action="store_true", help="禁用 SSL 证书验证 (适用于自签证书)"
+    )
+
+    args = parser.parse_args()
+
+    client = FnosClient()
+
+    try:
+        # 连接到服务器
+        # 1. 如果 endpoint 是 "192.168.1.100:5666"，会自动探测并转为 ws:// 或 wss://
+        # 2. 如果 endpoint 是 "ws://..." 或 "wss://..."，将直接使用指定的协议
+        # 3. 如果是自签证书 wss 连接，设置 ssl_verify=False
+
+        print(f"正在尝试连接到: {args.endpoint}")
+        ssl_verify = not args.no_verify
+
+        await client.connect(args.endpoint, ssl_verify=ssl_verify)
+
+        if client.connected:
+            print(f"连接成功! 实际使用的端点为: {client.endpoint}")
+
+            # 登录
+            print("正在登录...")
+            login_result = await client.login(args.user, args.password)
+
+            if login_result and login_result.get("result") == "succ":
+                print("登录成功")
+                # 获取系统信息作为演示
+                print("获取主机名...")
+                from fnos.system_info import SystemInfo
+
+                sys_info = SystemInfo(client)
+                host_name = await sys_info.get_host_name()
+                print(f"主机名: {host_name}")
+            else:
+                print(f"登录失败: {login_result.get('msg', '未知错误')}")
+        else:
+            print("连接失败")
+
+    except Exception as e:
+        print(f"发生错误: {e}")
+
+    finally:
+        await client.close()
+        print("连接已关闭")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
在飞牛开启强制 HTTPS 访问后， endpoint 会强制跳转为 https 协议和端口导致无法连接。
并且目前也无法自定义连接到 wss:// 协议。

<img width="661" height="726" alt="image" src="https://github.com/user-attachments/assets/b6e9e61f-ef18-42a1-b3cf-882eee9f5c3b" />

```log
https://192.168.8.8:5667/websocket?type=main isn't a valid URI: scheme isn't ws or wss
```

此 PR 增加 `_detect_endpoint()` 方法在 ws 连接前对 endpoint  识别和探测：

1. endpoint 兼容原 IP:PORT 的写法，自动识别探测 HTTPS 和跳转后的端口
2. endpoint 支持 ws://IP:PORT , wss://IP:PORT 的写法，手动设定是否使用 HTTPS/WSS
3. 默认开启 SSL 验证，如使用自签证书需在 connect() 传入 ssl_verify = True