### PR TITLE
feat: add Docker container lifecycle and image management methods

### DIFF
--- a/fnos/client.py
+++ b/fnos/client.py
@@ -23,7 +23,7 @@ import hashlib
 import hmac
 import logging
 import ssl
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin, urlparse, urlunparse
 from websockets.exceptions import InvalidStatus, InvalidURI
 from Crypto.PublicKey import RSA
 from Crypto.Cipher import AES, PKCS1_v1_5
@@ -125,7 +125,21 @@ class FnosClient:
         actual_use_ssl: bool,
     ) -> HTTPSRequiredError | None:
         """将匹配 fnOS 强制 HTTPS 的重定向异常转换为 SDK 异常。"""
-        if actual_use_ssl or urlparse(error.uri).scheme.lower() != "https":
+        if actual_use_ssl:
+            # WSS connection was redirected to HTTPS — the server returned
+            # a 302 to https:// but websockets followed it and failed to
+            # parse https:// as a WS URI.  Return the redirect target so
+            # the caller can retry with wss://.
+            redirect_uri = error.uri
+            if urlparse(redirect_uri).scheme.lower() == "https":
+                return HTTPSRequiredError(
+                    requested_uri=requested_uri,
+                    redirect_uri=redirect_uri,
+                    status_code=302,
+                )
+            return None
+
+        if urlparse(error.uri).scheme.lower() != "https":
             return None
 
         redirect_error = error.__cause__ or error.__context__
@@ -354,8 +368,16 @@ class FnosClient:
                     actual_use_ssl=actual_use_ssl,
                 )
                 if https_required_error is not None:
-                    raise https_required_error from error
-                raise
+                    # fnOS server redirected to HTTPS — retry with wss://
+                    redirect_uri = https_required_error.redirect_uri
+                    parts = urlparse(redirect_uri)
+                    new_uri = urlunparse(("wss",) + parts[1:])
+                    logger.debug(f"fnOS redirect detected, retrying with: {new_uri}")
+                    self.ws = await websockets.connect(
+                        new_uri, ssl=ssl_context
+                    )
+                else:
+                    raise
             logger.debug("websockets.connect returned")
 
             logger.debug("Creating async message handler...")

--- a/fnos/docker_manager.py
+++ b/fnos/docker_manager.py
@@ -207,3 +207,124 @@ class DockerManager:
         return await self.client.request_payload_with_response(
             "appcgi.dockermgr.registryHubRepoList", payload, timeout
         )
+
+    # ── Container lifecycle ──────────────────────────────────────────
+
+    async def container_inspect(
+        self, container_id: str, timeout: float = 10.0
+    ) -> dict:
+        """查看容器详情。"""
+        return await self.client.request_payload_with_response(
+            "appcgi.dockermgr.containerInspect",
+            {"containerId": container_id},
+            timeout,
+        )
+
+    async def container_top(
+        self, container_id: str, timeout: float = 10.0
+    ) -> dict:
+        """查看容器进程。"""
+        return await self.client.request_payload_with_response(
+            "appcgi.dockermgr.containerTop",
+            {"containerId": container_id},
+            timeout,
+        )
+
+    async def container_stats(
+        self, container_id: str, timeout: float = 10.0
+    ) -> dict:
+        """查看单容器资源统计（CPU/内存/网络）。"""
+        return await self.client.request_payload_with_response(
+            "appcgi.dockermgr.containerStats",
+            {"containerId": container_id},
+            timeout,
+        )
+
+    async def container_start(self, container_id: str, timeout: float = 30.0) -> dict:
+        """启动容器。"""
+        return await self.client.request_payload_with_response(
+            "appcgi.dockermgr.containerStart",
+            {"containerId": container_id},
+            timeout,
+        )
+
+    async def container_stop(self, container_id: str, timeout: float = 30.0) -> dict:
+        """停止容器。"""
+        return await self.client.request_payload_with_response(
+            "appcgi.dockermgr.containerStop",
+            {"containerId": container_id},
+            timeout,
+        )
+
+    async def container_restart(self, container_id: str, timeout: float = 30.0) -> dict:
+        """重启容器。"""
+        return await self.client.request_payload_with_response(
+            "appcgi.dockermgr.containerRestart",
+            {"containerId": container_id},
+            timeout,
+        )
+
+    async def container_kill(self, container_id: str, timeout: float = 30.0) -> dict:
+        """强制终止容器。"""
+        return await self.client.request_payload_with_response(
+            "appcgi.dockermgr.containerKill",
+            {"containerId": container_id},
+            timeout,
+        )
+
+    async def container_remove(
+        self, container_id: str, force: bool = False, timeout: float = 30.0
+    ) -> dict:
+        """删除容器。"""
+        payload: dict[str, object] = {"containerId": container_id}
+        if force:
+            payload["force"] = True
+        return await self.client.request_payload_with_response(
+            "appcgi.dockermgr.containerRemove", payload, timeout
+        )
+
+    # ── Image management ─────────────────────────────────────────────
+
+    async def image_pull(
+        self,
+        image_ref: str,
+        timeout: float = 120.0,
+    ) -> dict:
+        """拉取镜像。
+
+        Args:
+            image_ref: 镜像引用，如 'nginx:latest' 或 'registry:5000/ns/app:1.0'
+        """
+        if ":" in image_ref:
+            last_colon = image_ref.rfind(":")
+            from_image = image_ref[:last_colon]
+            tag = image_ref[last_colon + 1:]
+        else:
+            from_image = image_ref
+            tag = "latest"
+        return await self.client.request_payload_with_response(
+            "appcgi.dockermgr.imagePull",
+            {"fromImage": from_image, "tag": tag},
+            timeout,
+        )
+
+    async def image_remove(
+        self, image_id: str, force: bool = False, timeout: float = 30.0
+    ) -> dict:
+        """删除镜像。"""
+        payload: dict[str, object] = {"imageId": image_id}
+        if force:
+            payload["force"] = True
+        return await self.client.request_payload_with_response(
+            "appcgi.dockermgr.imageRemove", payload, timeout
+        )
+
+    async def image_inspect(
+        self, image_id: str, timeout: float = 10.0
+    ) -> dict:
+        """查看镜像详情。"""
+        return await self.client.request_payload_with_response(
+            "appcgi.dockermgr.imageInspect",
+            {"imageId": image_id},
+            timeout,
+        )


### PR DESCRIPTION
## Summary

Add Docker container lifecycle and image management methods to `DockerManager`, plus a fix for WSS connection when fnOS server returns HTTPS redirects.

### Container methods (8 new)
- `container_inspect` — inspect container details
- `container_top` — list container processes
- `container_stats` — single-container CPU/memory/network stats
- `container_start` — start a stopped container
- `container_stop` — stop a running container
- `container_restart` — restart a container
- `container_kill` — force-kill a container
- `container_remove` — remove a container (optional force)

### Image methods (3 new)
- `image_pull` — pull an image (supports `registry:port/ns/app:tag` format)
- `image_remove` — remove an image (optional force)
- `image_inspect` — inspect image details

### Bug fix
- `FnosClient.connect`: fnOS servers may respond to WSS connections with a 302 redirect to HTTPS. The websockets library follows the redirect but fails to parse `https://` as a WebSocket URI. The fix detects this pattern and retries with the URI scheme rewritten to `wss://` using `urlparse`/`urlunparse`.

### Testing
All new endpoints verified against fnOS 0.9.26 on real hardware.